### PR TITLE
200127 mitch service tests audit

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -79,4 +79,4 @@ export const getRoutableComponents = () => {
     });
   }
   return components;
-}
+};

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,5 +1,5 @@
-import { NgModule } from '@angular/core';
-import { Routes, RouterModule } from '@angular/router';
+import { NgModule, Component, Type } from '@angular/core';
+import { Routes, RouterModule, Route } from '@angular/router';
 import { AdminComponent } from './components/admin/admin.component';
 import { CarRegisterComponent } from './components/car-register/car-register.component';
 import { RegisterComponent } from './components/register/register.component';
@@ -44,9 +44,39 @@ const routes: Routes = [
   { path: '', component: HomePageComponent },
   { path: '**', pathMatch: 'full', redirectTo: '' }];
 
-
 @NgModule({
   imports: [RouterModule.forRoot(routes)],
   exports: [RouterModule]
 })
 export class AppRoutingModule { }
+
+
+/**
+ * Function that provides a component list for testing
+ * classes that leverage the router.  For whatever reason
+ * the test classes require declarations for every component
+ * used in the router, even when it is being mocked. There
+ * should be a more elegant solution for this as I have not
+ * had to do this in older projects - for the time being this
+ * helper function can be used to keep unit test component
+ * declarations up to date with the router's components.
+ */
+export const getRoutableComponents = () => {
+  const components = new Set<Type<any>>();
+  const routeQueue: Routes[] = [];
+
+  routeQueue.push(routes);
+  while (routeQueue.length > 0) {
+    const currentRoutes = routeQueue.pop();
+    currentRoutes.forEach((r) => {
+      if (r.component) {
+        components.add(r.component);
+      }
+
+      if (r.children) {
+        routeQueue.push(r.children);
+      }
+    });
+  }
+  return components;
+}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -62,7 +62,7 @@ import { BsNavbarComponent } from './bs-navbar/bs-navbar.component';
     DriverListComponent,
     UserRegisterComponent,
     HomePageComponent,
-    BsNavbarComponent
+    BsNavbarComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/admin/admin.component.spec.ts
+++ b/src/app/components/admin/admin.component.spec.ts
@@ -3,11 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { AdminComponent } from './admin.component';
 import { CarRegisterComponent } from '../car-register/car-register.component';
 import { UserRegisterComponent } from '../user-register/user-register.component';
-import { RegisterComponent } from '../register/register.component';
 import { LoginComponent } from '../login/login.component';
-import { HttpClientModule } from '@angular/common/http';
-import { AppRoutingModule } from 'src/app/app-routing.module';
-import { FormsModule } from '@angular/forms';
 import { APP_BASE_HREF } from '@angular/common';
 import { MyCarComponent } from '../my-car/my-car.component';
 import { NavbarComponent } from '../navbar/navbar.component';
@@ -24,7 +20,6 @@ describe('AdminComponent', () => {
     TestBed.configureTestingModule({
       declarations: [AdminComponent, MyCarComponent, NavbarComponent,
         PreferenceComponent, ProfileComponent, CarRegisterComponent, UserRegisterComponent, LoginComponent],
-      imports: [HttpClientModule, AppRoutingModule, FormsModule],
       providers: [{ provide: APP_BASE_HREF, useValue: '/my/app' }]
     })
       .compileComponents();

--- a/src/app/services/admin-service/admin.service.spec.ts
+++ b/src/app/services/admin-service/admin.service.spec.ts
@@ -1,9 +1,14 @@
 import { TestBed } from '@angular/core/testing';
 
 import { AdminService } from './admin.service';
+import { getRoutableComponents } from 'src/app/app-routing.module';
 
 describe('AdminService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+  beforeEach(() => TestBed.configureTestingModule({
+    declarations: [
+      ...getRoutableComponents()
+    ]
+  }));
 
   it('should be created', () => {
     const service: AdminService = TestBed.get(AdminService);

--- a/src/app/services/auth-service/auth.service.spec.ts
+++ b/src/app/services/auth-service/auth.service.spec.ts
@@ -3,22 +3,15 @@ import { TestBed } from '@angular/core/testing';
 import { AuthService } from './auth.service';
 import { APP_BASE_HREF } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
-import { AppRoutingModule } from 'src/app/app-routing.module';
+import { AppRoutingModule, getRoutableComponents } from 'src/app/app-routing.module';
 import { FormsModule } from '@angular/forms';
-import { AdminComponent } from 'src/app/components/admin/admin.component';
-import { CarRegisterComponent } from 'src/app/components/car-register/car-register.component';
-import { UserRegisterComponent } from 'src/app/components/user-register/user-register.component';
-import { LoginComponent } from 'src/app/components/login/login.component';
-import { MyCarComponent } from 'src/app/components/my-car/my-car.component';
-import { NavbarComponent } from 'src/app/components/navbar/navbar.component';
-import { PreferenceComponent } from 'src/app/components/preference/preference.component';
-import { ProfileComponent } from 'src/app/components/profile/profile.component';
 
 
 describe('AuthService', () => {
   beforeEach(() => TestBed.configureTestingModule({
-    declarations: [AdminComponent, CarRegisterComponent, UserRegisterComponent,
-      LoginComponent, MyCarComponent, NavbarComponent, PreferenceComponent, ProfileComponent],
+    declarations: [
+      ...getRoutableComponents()
+    ],
     imports: [AppRoutingModule, FormsModule, HttpClientModule],
     providers: [{ provide: APP_BASE_HREF, useValue: '/my/app' }]
   }));
@@ -26,15 +19,9 @@ describe('AuthService', () => {
 
   beforeEach(() => {
     service = TestBed.get(AuthService);
-    service.loggedIn = false;
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
-  });
-
-  it('#isLoggedIn() should confirm if logged in', () => {
-    service.loggedIn = false;
-    expect(service.loggedIn).toBe(false);
   });
 });

--- a/src/app/services/auth-service/auth.service.spec.ts
+++ b/src/app/services/auth-service/auth.service.spec.ts
@@ -8,7 +8,6 @@ import { FormsModule } from '@angular/forms';
 import { AdminComponent } from 'src/app/components/admin/admin.component';
 import { CarRegisterComponent } from 'src/app/components/car-register/car-register.component';
 import { UserRegisterComponent } from 'src/app/components/user-register/user-register.component';
-import { RegisterComponent } from 'src/app/components/register/register.component';
 import { LoginComponent } from 'src/app/components/login/login.component';
 import { MyCarComponent } from 'src/app/components/my-car/my-car.component';
 import { NavbarComponent } from 'src/app/components/navbar/navbar.component';
@@ -18,25 +17,24 @@ import { ProfileComponent } from 'src/app/components/profile/profile.component';
 
 describe('AuthService', () => {
   beforeEach(() => TestBed.configureTestingModule({
-    declarations: [AdminComponent, CarRegisterComponent, UserRegisterComponent, LoginComponent, MyCarComponent, NavbarComponent, PreferenceComponent, ProfileComponent],
+    declarations: [AdminComponent, CarRegisterComponent, UserRegisterComponent,
+      LoginComponent, MyCarComponent, NavbarComponent, PreferenceComponent, ProfileComponent],
     imports: [AppRoutingModule, FormsModule, HttpClientModule],
-    providers: [{provide: APP_BASE_HREF, useValue: '/my/app'}]
+    providers: [{ provide: APP_BASE_HREF, useValue: '/my/app' }]
   }));
-   let service: AuthService;
-   
+  let service: AuthService;
+
   beforeEach(() => {
     service = TestBed.get(AuthService);
     service.loggedIn = false;
   });
 
   it('should be created', () => {
-    // const service: AuthService = TestBed.get(AuthService);
     expect(service).toBeTruthy();
   });
 
   it('#isLoggedIn() should confirm if logged in', () => {
-    // const isLoggedIn = false;
     service.loggedIn = false;
     expect(service.loggedIn).toBe(false);
-  })
+  });
 });

--- a/src/app/services/batch-service/batch.service.spec.ts
+++ b/src/app/services/batch-service/batch.service.spec.ts
@@ -2,21 +2,14 @@ import { TestBed } from '@angular/core/testing';
 import { BatchService } from './batch.service';
 import { APP_BASE_HREF } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
-import { AppRoutingModule } from 'src/app/app-routing.module';
+import { AppRoutingModule, getRoutableComponents } from 'src/app/app-routing.module';
 import { FormsModule } from '@angular/forms';
-import { AdminComponent } from 'src/app/components/admin/admin.component';
-import { CarRegisterComponent } from 'src/app/components/car-register/car-register.component';
-import { UserRegisterComponent } from 'src/app/components/user-register/user-register.component';
-import { LoginComponent } from 'src/app/components/login/login.component';
-import { MyCarComponent } from 'src/app/components/my-car/my-car.component';
-import { NavbarComponent } from 'src/app/components/navbar/navbar.component';
-import { PreferenceComponent } from 'src/app/components/preference/preference.component';
-import { ProfileComponent } from 'src/app/components/profile/profile.component';
 
 describe('BatchService', () => {
   beforeEach(() => TestBed.configureTestingModule({
-    declarations: [AdminComponent, CarRegisterComponent, UserRegisterComponent,
-      LoginComponent, MyCarComponent, NavbarComponent, PreferenceComponent, ProfileComponent],
+    declarations: [
+      ...getRoutableComponents()
+    ],
     imports: [HttpClientModule, AppRoutingModule, FormsModule],
     providers: [{ provide: APP_BASE_HREF, useValue: '/my/app' }]
   }));

--- a/src/app/services/batch-service/batch.service.spec.ts
+++ b/src/app/services/batch-service/batch.service.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-
 import { BatchService } from './batch.service';
 import { APP_BASE_HREF } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
@@ -8,14 +7,11 @@ import { FormsModule } from '@angular/forms';
 import { AdminComponent } from 'src/app/components/admin/admin.component';
 import { CarRegisterComponent } from 'src/app/components/car-register/car-register.component';
 import { UserRegisterComponent } from 'src/app/components/user-register/user-register.component';
-import { RegisterComponent } from 'src/app/components/register/register.component';
 import { LoginComponent } from 'src/app/components/login/login.component';
-import { of } from 'rxjs';
 import { MyCarComponent } from 'src/app/components/my-car/my-car.component';
 import { NavbarComponent } from 'src/app/components/navbar/navbar.component';
 import { PreferenceComponent } from 'src/app/components/preference/preference.component';
 import { ProfileComponent } from 'src/app/components/profile/profile.component';
-import { Batch } from 'src/app/models/batch';
 
 describe('BatchService', () => {
   beforeEach(() => TestBed.configureTestingModule({
@@ -28,47 +24,5 @@ describe('BatchService', () => {
   it('should be created', () => {
     const service: BatchService = TestBed.get(BatchService);
     expect(service).toBeTruthy();
-  });
-});
-
-
-
-describe('BatchService', () => {
-  let batchService: BatchService;
-
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [AdminComponent, CarRegisterComponent, UserRegisterComponent,
-        LoginComponent, MyCarComponent, NavbarComponent, PreferenceComponent, ProfileComponent],
-      imports: [HttpClientModule, AppRoutingModule, FormsModule],
-      providers: [{ provide: APP_BASE_HREF, useValue: '/my/app' }]
-    });
-
-    batchService = TestBed.get(BatchService);
-  });
-
-  it('should register a batch', () => {
-    expect(batchService).toBeTruthy();
-  });
-
-  // Adding test for getAllBatches() method
-  describe('getAllBatches', () => {
-    it('should return a list of batches', () => {
-      const batchResponse: Batch[] = [
-        {
-          batchNumber: 1,
-          batchLocation: 'NYC'
-        },
-        {
-          batchNumber: 2,
-          batchLocation: 'VA'
-        }
-      ];
-      spyOn(batchService, 'getAllBatches').and.returnValue(batchResponse);
-
-      const response: Batch[] = batchService.getAllBatches();
-
-      expect(response).toEqual(batchResponse);
-    });
   });
 });

--- a/src/app/services/car-service/car.service.spec.ts
+++ b/src/app/services/car-service/car.service.spec.ts
@@ -2,10 +2,12 @@ import { TestBed } from '@angular/core/testing';
 
 import { CarService } from './car.service';
 import { APP_BASE_HREF } from '@angular/common';
-import { UserService } from 'src/app/services/user-service/user.service';
 import { RouterTestingModule } from '@angular/router/testing';
-import { MyCarComponent } from 'src/app/components/my-car/my-car.component';
 import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { UserService } from 'src/app/services/user-service/user.service';
+import { HttpClient } from 'selenium-webdriver/http';
+import { getRoutableComponents } from 'src/app/app-routing.module';
 
 @Component({ template: '' })
 class DummyComponent {
@@ -13,9 +15,20 @@ class DummyComponent {
 }
 
 describe('CarService', () => {
-  beforeEach(() =>
+
+  let mockRouter: { navigate: jasmine.Spy };
+  let mockHttpClient: {};
+  let mockUserService: {};
+  beforeEach(() => {
+
+    mockRouter = jasmine.createSpyObj('Router', ['navigate']);
+    mockHttpClient = jasmine.createSpyObj('HttpClient', ['get', 'post', 'delete']);
+    mockUserService = jasmine.createSpyObj('UserService', ['updateIsDriver']);
+
     TestBed.configureTestingModule({
       declarations: [
+        DummyComponent,
+        ...getRoutableComponents()
       ],
       imports: [
         RouterTestingModule.withRoutes(
@@ -23,16 +36,16 @@ describe('CarService', () => {
         )
       ],
       providers: [{ provide: APP_BASE_HREF, useValue: '/my/app' },
-      { provide: UserService, userClass: MockUserService }]
-    }));
+      { provide: UserService, useValue: mockUserService },
+      { provide: Router, useValue: mockRouter },
+      { provide: HttpClient, useValue: mockHttpClient }
+      ]
+    });
+  });
 
-  fit('should be created', () => {
+  it('should be created', () => {
     const service: CarService = TestBed.get(CarService);
     expect(service).toBeTruthy();
   });
 });
 
-
-class MockUserService {
-
-}

--- a/src/app/services/car-service/car.service.spec.ts
+++ b/src/app/services/car-service/car.service.spec.ts
@@ -1,125 +1,38 @@
 import { TestBed } from '@angular/core/testing';
 
 import { CarService } from './car.service';
-import { AdminComponent } from 'src/app/components/admin/admin.component';
-import { CarRegisterComponent } from 'src/app/components/car-register/car-register.component';
-import { UserRegisterComponent } from 'src/app/components/user-register/user-register.component';
-import { RegisterComponent } from 'src/app/components/register/register.component';
-import { LoginComponent } from 'src/app/components/login/login.component';
-import { HttpClientModule } from '@angular/common/http';
-import { AppRoutingModule } from 'src/app/app-routing.module';
-import { FormsModule } from '@angular/forms';
 import { APP_BASE_HREF } from '@angular/common';
-import { of } from 'rxjs';
+import { UserService } from 'src/app/services/user-service/user.service';
+import { RouterTestingModule } from '@angular/router/testing';
 import { MyCarComponent } from 'src/app/components/my-car/my-car.component';
-import { NavbarComponent } from 'src/app/components/navbar/navbar.component';
-import { PreferenceComponent } from 'src/app/components/preference/preference.component';
-import { ProfileComponent } from 'src/app/components/profile/profile.component';
-import { Car } from 'src/app/models/car';
+import { Component } from '@angular/core';
+
+@Component({ template: '' })
+class DummyComponent {
+
+}
 
 describe('CarService', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
-      declarations: [AdminComponent, CarRegisterComponent, UserRegisterComponent,
-        LoginComponent, MyCarComponent, NavbarComponent, PreferenceComponent, ProfileComponent],
-      imports: [HttpClientModule, AppRoutingModule, FormsModule],
-      providers: [{ provide: APP_BASE_HREF, useValue: '/my/app' }]
+      declarations: [
+      ],
+      imports: [
+        RouterTestingModule.withRoutes(
+          [{ path: 'car', component: DummyComponent }]
+        )
+      ],
+      providers: [{ provide: APP_BASE_HREF, useValue: '/my/app' },
+      { provide: UserService, userClass: MockUserService }]
     }));
 
-  it('should be created', () => {
+  fit('should be created', () => {
     const service: CarService = TestBed.get(CarService);
     expect(service).toBeTruthy();
   });
 });
 
-describe('CarService', () => {
-  let carService: CarService;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [AdminComponent, CarRegisterComponent, UserRegisterComponent,
-        LoginComponent, MyCarComponent, NavbarComponent, PreferenceComponent, ProfileComponent],
-      imports: [HttpClientModule, AppRoutingModule, FormsModule],
-      providers: [{ provide: APP_BASE_HREF, useValue: '/my/app' }]
-    })
+class MockUserService {
 
-    carService = TestBed.get(CarService);
-  })
-
-  it('should register a car', () => {
-    expect(carService).toBeTruthy();
-  });
-
-  // Helper object to fillout properties for meeting User object definition
-  const genericUserData = {
-    isDriver: true,
-    active: true,
-    isAcceptingRides: true,
-    hState: '',
-    hAddress: '',
-    hCity: '',
-    hZip: 13456,
-    wAddress: '',
-    wCity: '',
-    wState: '',
-    wZip: 12345
-  };
-
-  // Adding test for getAllCars() method
-  describe('getAllCars', () => {
-    it('should return a collection of cars', () => {
-      const carsResponse: Car[] = [
-        {
-          carId: 1,
-          color: 'black',
-          seats: 6,
-          make: 'Tesla',
-          model: 'Model X',
-          year: 2019,
-          user: {
-            userId: 1,
-            userName: 'carsryan',
-            batch: {
-              batchNumber: 1,
-              batchLocation: '123'
-            },
-            firstName: 'Ryan',
-            lastName: 'Carstons',
-            email: 'ryan@gmail.com',
-            phoneNumber: '1231231231',
-            ...genericUserData
-          }
-        },
-        {
-          carId: 2,
-          color: 'white',
-          seats: 4,
-          make: 'Toyota',
-          model: 'Supra',
-          year: 2019,
-          user: {
-            userId: 2,
-            userName: 'pwin',
-            batch: {
-              batchNumber: 2,
-              batchLocation: '456'
-            },
-            firstName: 'Peter',
-            lastName: 'Nguyen',
-            email: 'pete@gmail.com',
-            phoneNumber: '3213213213',
-            ...genericUserData
-          }
-        }
-      ];
-      let response;
-      spyOn(carService, 'getAllCars').and.returnValue(of(carsResponse));
-
-      carService.getAllCars().subscribe(res => {
-        response = res;
-      });
-
-      expect(response).toEqual(carsResponse);
-    });
-  });
-});
+}

--- a/src/app/services/car-service/car.service.ts
+++ b/src/app/services/car-service/car.service.ts
@@ -8,7 +8,7 @@ import { environment } from '../../../environments/environment';
 import { Observable } from 'rxjs';
 
 @Injectable({
-    providedIn: 'root'
+	providedIn: 'root'
 })
 /**
  * This is a car service
@@ -19,7 +19,7 @@ export class CarService {
 	 * An user is created.
 	 */
 
-    url: string = environment.carUri;
+	url: string = environment.carUri;
 	user: User = new User();
 
 	/**
@@ -53,7 +53,6 @@ export class CarService {
 	}
 
 	updateCarInfo(car: Car) {
-		//console.log(user);
 		return this.http.put(this.url, car).toPromise();
 	}
 
@@ -61,16 +60,15 @@ export class CarService {
 
 	/**
 	 * This function creates a car.
-	 * @param car 
-	 * @param userId 
-	 */
-	
+	 * @param car
+   * @param userId
+   */
 	createCar(car, userId) {
 
 		this.user.userId = userId;
 		car.user = this.user;
 
-		this.http.post(this.url, car, {observe: 'response'}).subscribe(
+		this.http.post(this.url, car, { observe: 'response' }).subscribe(
 			(response) => {
 				if (response) {
 					this.userService.updateIsDriver(true, userId);
@@ -85,10 +83,10 @@ export class CarService {
 
 	/**
 	 * This function removes a Car.
-	 * @param carId 
+	 * @param carId
 	 */
 
 	removeCar(carId: number) {
-		return this.http.delete<Car>(this.url+carId);
+		return this.http.delete<Car>(this.url + carId);
 	}
 }

--- a/src/app/services/log.service.spec.ts
+++ b/src/app/services/log.service.spec.ts
@@ -1,9 +1,14 @@
 import { TestBed } from '@angular/core/testing';
 
 import { LogService } from './log.service';
+import { getRoutableComponents } from 'src/app/app-routing.module';
 
 describe('LogService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+  beforeEach(() => TestBed.configureTestingModule({
+    declarations: [
+      ...getRoutableComponents()
+    ]
+  }));
 
   it('should be created', () => {
     const service: LogService = TestBed.get(LogService);

--- a/src/app/services/mark-inactive-driver.service.spec.ts
+++ b/src/app/services/mark-inactive-driver.service.spec.ts
@@ -1,9 +1,14 @@
 import { TestBed } from '@angular/core/testing';
 
 import { UserService } from './user-service/user.service';
+import { getRoutableComponents } from 'src/app/app-routing.module';
 
 describe('MarkInactiveDriverService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+  beforeEach(() => TestBed.configureTestingModule({
+    declarations: [
+      ...getRoutableComponents()
+    ]
+  }));
 
   it('should be created', () => {
     const service: UserService = TestBed.get(UserService);

--- a/src/app/services/user-service/user.service.spec.ts
+++ b/src/app/services/user-service/user.service.spec.ts
@@ -46,63 +46,7 @@ describe('UserService', () => {
     userService = TestBed.get(UserService);
   });
 
-  it('should create a user', () => {
+  it('should create be created', () => {
     expect(userService).toBeTruthy();
-  });
-
-  const genericUserData = {
-    isDriver: true,
-    active: true,
-    isAcceptingRides: true,
-    hState: '',
-    hAddress: '',
-    hCity: '',
-    hZip: 13456,
-    wAddress: '',
-    wCity: '',
-    wState: '',
-    wZip: 12345
-  };
-
-  // Adding test for getAllUsers() method
-  describe('getAllUsers', () => {
-    it('should return a collection of users', () => {
-      const userResponse: User[] = [
-        {
-          userId: 1,
-          userName: 'carsryan',
-          batch: {
-            batchNumber: 1,
-            batchLocation: '123'
-          },
-          firstName: 'Ryan',
-          lastName: 'Carstons',
-          email: 'ryan@gmail.com',
-          phoneNumber: '1231231231',
-          ...genericUserData
-        },
-        {
-          userId: 2,
-          userName: 'pwin',
-          batch: {
-            batchNumber: 2,
-            batchLocation: '456'
-          },
-          firstName: 'Peter',
-          lastName: 'Nguyen',
-          email: 'pete@gmail.com',
-          phoneNumber: '3213213213',
-          ...genericUserData
-        }
-      ];
-      let response;
-      spyOn(userService, 'getAllUsers').and.returnValue(of(userResponse));
-
-      userService.getAllUsers().subscribe(res => {
-        response = res;
-      });
-
-      expect(response).toEqual(userResponse);
-    });
   });
 });

--- a/src/app/services/user-service/user.service.spec.ts
+++ b/src/app/services/user-service/user.service.spec.ts
@@ -6,7 +6,7 @@ import { CarRegisterComponent } from 'src/app/components/car-register/car-regist
 import { UserRegisterComponent } from 'src/app/components/user-register/user-register.component';
 import { LoginComponent } from 'src/app/components/login/login.component';
 import { HttpClientModule } from '@angular/common/http';
-import { AppRoutingModule } from 'src/app/app-routing.module';
+import { AppRoutingModule, getRoutableComponents } from 'src/app/app-routing.module';
 import { FormsModule } from '@angular/forms';
 import { APP_BASE_HREF } from '@angular/common';
 import { of } from 'rxjs';
@@ -19,34 +19,14 @@ import { User } from 'src/app/models/user';
 
 describe('UserService', () => {
   beforeEach(() => TestBed.configureTestingModule({
-    declarations: [AdminComponent, CarRegisterComponent, UserRegisterComponent,
-      LoginComponent, MyCarComponent, NavbarComponent, PreferenceComponent, ProfileComponent],
-    imports: [HttpClientModule, AppRoutingModule, FormsModule],
+    declarations: [
+      ...getRoutableComponents()
+    ],
     providers: [{ provide: APP_BASE_HREF, useValue: '/my/app' }]
   }));
 
   it('should be created', () => {
     const service: UserService = TestBed.get(UserService);
     expect(service).toBeTruthy();
-  });
-});
-
-describe('UserService', () => {
-  let userService: UserService;
-
-  // Adding injection here instead of it() method to reduce redundancy
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [AdminComponent, CarRegisterComponent, UserRegisterComponent,
-        LoginComponent, MyCarComponent, NavbarComponent, PreferenceComponent, ProfileComponent],
-      imports: [HttpClientModule, AppRoutingModule, FormsModule],
-      providers: [{ provide: APP_BASE_HREF, useValue: '/my/app' }]
-    });
-
-    userService = TestBed.get(UserService);
-  });
-
-  it('should create be created', () => {
-    expect(userService).toBeTruthy();
   });
 });

--- a/src/app/services/validation-service/validation.service.spec.ts
+++ b/src/app/services/validation-service/validation.service.spec.ts
@@ -1,9 +1,14 @@
 import { TestBed } from '@angular/core/testing';
 
 import { ValidationService } from './validation.service';
+import { getRoutableComponents } from 'src/app/app-routing.module';
 
 describe('ValidationService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+  beforeEach(() => TestBed.configureTestingModule({
+    declarations: [
+      ...getRoutableComponents()
+    ]
+  }));
 
   it('should be created', () => {
     const service: ValidationService = TestBed.get(ValidationService);

--- a/src/test.ts
+++ b/src/test.ts
@@ -6,12 +6,20 @@ import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
-
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { FormsModule } from '@angular/forms';
+import { AppRoutingModule } from 'src/app/app-routing.module';
 declare const require: any;
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(
+getTestBed().initTestEnvironment([
   BrowserDynamicTestingModule,
+  HttpClientTestingModule,
+  RouterTestingModule,
+  AppRoutingModule,
+  FormsModule,
+],
   platformBrowserDynamicTesting()
 );
 // Then we find all the tests.

--- a/src/test.ts
+++ b/src/test.ts
@@ -30,10 +30,3 @@ getTestBed().initTestEnvironment([
 const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.
 context.keys().map(context);
-
-/**
- * Array of components used by the Router.  These are declared to make it easier
- * to declare them testing files that leverage the router. This should not be necessary -
- * I've not had to do this in other projects, but could not figure out a way to prevent
- * routed components to break tests.
- */

--- a/src/test.ts
+++ b/src/test.ts
@@ -10,6 +10,10 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FormsModule } from '@angular/forms';
 import { AppRoutingModule } from 'src/app/app-routing.module';
+import { DriverInfoComponent } from 'src/app/components/driver-info/driver-info.component';
+import { DriverComponent } from 'src/app/components/driver/driver.component';
+import { LoginComponent } from 'src/app/components/login/login.component';
+import { AdminLoginComponent } from 'src/app/components/admin-login/admin-login.component';
 declare const require: any;
 
 // First, initialize the Angular testing environment.
@@ -26,3 +30,10 @@ getTestBed().initTestEnvironment([
 const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.
 context.keys().map(context);
+
+/**
+ * Array of components used by the Router.  These are declared to make it easier
+ * to declare them testing files that leverage the router. This should not be necessary -
+ * I've not had to do this in other projects, but could not figure out a way to prevent
+ * routed components to break tests.
+ */


### PR DESCRIPTION
# Service Tests Audit
Conducted an audit over tests on service classes with the following goals:
- [x] Remove tests that do not test any actual implementation logic
- [x] Fix existing tests
- [x] Provide mechanisms to make tests less brittle and to require less maintenance

## Useless Test
Some tests that existed in the project used extremely naive approaches which did not actually test the implementation logic of the services they were meant to cover.

Some examples of such tests:

```typescript
spyOn(userService, 'getAllUsers').and.returnValue(of(userResponse));

userService.getAllUsers().subscribe(res => {
  response = res;
});

expect(response).toEqual(userResponse);
```
This test created a stub method, called the stubbed method, then asserted that the stub returned the value that the stub declared in the test said it should.  No actual service logic was called and the only thing the test tests is the implementation of Jasmine's stubs.  This is not a useful test - tests of this form were removed.

```typescript
it('#isLoggedIn() should confirm if logged in', () => {
  service.loggedIn = false;
  expect(service.loggedIn).toBe(false);
})
```
This test directly sets a value then tests that the value was set. Save for the rare case that computed properties are being used (which is not the case here) this tests no actual implementation logic of the target service.  Tests of this form were removed.

## Fix Existing Tests
The majority of remaining tests were failing due to declarations not including all dependent components.  This appears to be because they all depend on the routing module, which thus requires declaring all components that can be routed to.  There should be a way to avoid having to do this - however even when fully stubbing the Router with a Spy the tests would still fail without importing all declared components.  To make this less brittle, I created a helper method to produce a list of components declared in the app router module which is then called by any tests which require supporting the Router.

## Simple Router Component Injection
As described above, many TestBed configuration require declarations of components in the router module.  Changes to the router then risk breaking all such tests when declared explicitly.  To prevent this a method was created to produce a set of Components from the router's declared components:

```typescript
export const getRoutableComponents = () => {
  const components = new Set<Type<any>>();
  const routeQueue: Routes[] = [];

  routeQueue.push(routes);
  while (routeQueue.length > 0) {
    const currentRoutes = routeQueue.pop();
    currentRoutes.forEach((r) => {
      if (r.component) {
        components.add(r.component);
      }

      if (r.children) {
        routeQueue.push(r.children);
      }
    });
  }
  return components;
};
```

This method can then be imported from the router module and used in declarations like so:
```typescript
  beforeEach(() => TestBed.configureTestingModule({
    declarations: [
      ...getRoutableComponents()
    ]
  }));
```
